### PR TITLE
Specifically call `na_if()` on columns

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,8 @@ Imports:
     jsonlite,
     memoise,
     rlang,
-    tidyr
+    tidyr,
+    tidyselect
 RoxygenNote: 7.2.1
 Suggests: 
     knitr,

--- a/R/assessment_glance.R
+++ b/R/assessment_glance.R
@@ -100,9 +100,9 @@ assessment_glance <- function(data_set) {
                          extra = "merge")
   }
 
-  data_set <- na_if(data_set, "n/a")
-  data_set <- na_if(data_set, "")
-  data_set <- na_if(data_set, "0000-00-00")
+  data_set <- mutate(data_set, across(tidyselect::where(is.character), ~na_if(.x, "n/a")))
+  data_set <- mutate(data_set, across(tidyselect::where(is.character), ~na_if(.x, "")))
+  data_set <- mutate(data_set, across(tidyselect::where(is.character), ~na_if(.x, "0000-00-00")))
 
   data_set[1, 2] <- data_set[1, 1]
   data_set[1, 1] <- "Title"

--- a/R/assessment_inventory.R
+++ b/R/assessment_inventory.R
@@ -58,8 +58,8 @@ assessment_inventory <- function(data_set) {
                          extra = "merge")
   }
 
-  data_set <- na_if(data_set, "n/a")
-  data_set <- na_if(data_set, "")
+  data_set <- mutate(data_set, across(tidyselect::where(is.character), ~na_if(.x, "n/a")))
+  data_set <- mutate(data_set, across(tidyselect::where(is.character), ~na_if(.x, "")))
 
   renamed <- data_set |>
     rename("scientific_name" = 1,

--- a/R/transect_glance.R
+++ b/R/transect_glance.R
@@ -102,9 +102,9 @@ transect_glance <- function(data_set){
                          extra = "merge")
   }
 
-  data_set <- na_if(data_set, "n/a")
-  data_set <- na_if(data_set, "")
-  data_set <- na_if(data_set, "0000-00-00")
+  data_set <- mutate(data_set, across(tidyselect::where(is.character), ~na_if(.x, "n/a")))
+  data_set <- mutate(data_set, across(tidyselect::where(is.character), ~na_if(.x, "")))
+  data_set <- mutate(data_set, across(tidyselect::where(is.character), ~na_if(.x, "0000-00-00")))
 
   data_set[1, 2] <- data_set[1, 1]
   data_set[1, 1] <- "Title"

--- a/R/transect_inventory.R
+++ b/R/transect_inventory.R
@@ -63,8 +63,8 @@ transect_inventory <- function(data_set) {
                          extra = "merge")
   }
 
-  data_set <- na_if(data_set, "n/a")
-  data_set <- na_if(data_set, "")
+  data_set <- mutate(data_set, across(tidyselect::where(is.character), ~na_if(.x, "n/a")))
+  data_set <- mutate(data_set, across(tidyselect::where(is.character), ~na_if(.x, "")))
 
   data_set <- data_set |> select(1:13)
 

--- a/R/transect_phys.R
+++ b/R/transect_phys.R
@@ -57,8 +57,8 @@ transect_phys <- function(data_set) {
                          extra = "merge")
   }
 
-  data_set <- na_if(data_set, "n/a")
-  data_set <- na_if(data_set, "")
+  data_set <- mutate(data_set, across(tidyselect::where(is.character), ~na_if(.x, "n/a")))
+  data_set <- mutate(data_set, across(tidyselect::where(is.character), ~na_if(.x, "")))
 
   start_row <- 2 + which(data_set$V1 == "Physiognomic Relative Importance Values:")
   end_row <- -2 + which(data_set$V1 == "Species Relative Importance Values:")

--- a/R/transect_subplot_inventories.R
+++ b/R/transect_subplot_inventories.R
@@ -66,8 +66,8 @@ transect_subplot_inventories <- function(transect){
                            "duration",
                            "common_name")
 
-    sub_inv <- dplyr::na_if(sub_inv, "n/a")
-    sub_inv <- dplyr::na_if(sub_inv, "")
+    sub_inv <- mutate(sub_inv, across(tidyselect::where(is.character), ~na_if(.x, "n/a")))
+    sub_inv <- mutate(sub_inv, across(tidyselect::where(is.character), ~na_if(.x, "")))
 
     sub_inv <- sub_inv |>
       dplyr::mutate(c = as.numeric(.data$c),


### PR DESCRIPTION
This PR makes your package compatible with the next version of dplyr:

`na_if()` now uses vctrs. It previously accidentally allowed you to apply it to an entire data frame at once, but this was never the actual intention of this function, it is meant to be applied to a single column at a time. Applying it to a data frame like this now errors, so I've updated your usage to correctly apply it to only your character columns.

We plan to submit dplyr 1.1.0 on January 27th.

This should be compatible with both dev and CRAN dplyr. It would help us out if you could go ahead and send a patch version of your package to CRAN ahead of time! Thanks!